### PR TITLE
Add frontend SEO checker

### DIFF
--- a/frontend/UXUI/Components/Posts/Post.jsx
+++ b/frontend/UXUI/Components/Posts/Post.jsx
@@ -1,5 +1,5 @@
 import { Helmet } from "react-helmet-async";
-import { runSeoCheck } from "../utils/seoCheckRunner";
+import { runSeoCheck } from "@/lib/seoCheckRunner";
 
 const Post = ({ post }) => {
 	const seo = runSeoCheck(post.id); // or title/slug

--- a/frontend/UXUI/Components/Posts/SeoFolder/seoTags.jsx
+++ b/frontend/UXUI/Components/Posts/SeoFolder/seoTags.jsx
@@ -1,7 +1,7 @@
 /** @format */
 import { Helmet } from "react-helmet-async";
 import PropTypes from "prop-types";
-import { runSeoCheck } from "../utils/seoCheckRunner";
+import { runSeoCheck } from "@/lib/seoCheckRunner";
 
 const defaultSchema = (meta) => ({
   "@context": "https://schema.org",

--- a/frontend/UXUI/lib/seoCheckRunner.js
+++ b/frontend/UXUI/lib/seoCheckRunner.js
@@ -1,0 +1,52 @@
+/** @format */
+
+// /UXUI/lib/seoCheckRunner.js
+import { seoProducts } from "./seoPresets.js";
+
+export function runSeoCheck(productKey) {
+  const data = seoProducts[productKey];
+
+  if (!data) {
+    return {
+      ok: false,
+      error: `❌ No SEO metadata found for '${productKey}'`,
+    };
+  }
+
+  const schema = {
+    "@context": "https://schema.org",
+    "@type": "SoftwareApplication",
+    name: data.title,
+    description: data.description,
+    operatingSystem: "Cross-platform",
+    applicationCategory: "DeveloperTool",
+    offers: {
+      "@type": "Offer",
+      priceCurrency: "USD",
+      price: data.price,
+      url: data.url,
+    },
+    author: {
+      "@type": "Person",
+      name: "Ashley Broussard",
+    },
+  };
+
+  return {
+    ok: true,
+    meta: {
+      title: data.title,
+      description: data.description,
+      image: data.image,
+      url: data.url,
+    },
+    schema,
+    todoLinks: {
+      metatags: "https://metatags.io/",
+      pagespeed: "https://pagespeed.web.dev/",
+      console: "https://search.google.com/search-console/",
+      answerThePublic: "https://answerthepublic.com/",
+      trends: "https://trends.google.com/",
+    },
+  };
+}

--- a/frontend/UXUI/lib/seoPresets.js
+++ b/frontend/UXUI/lib/seoPresets.js
@@ -1,0 +1,33 @@
+/** @format */
+
+export const seoDefaults = {
+        platform: "Cross-platform",
+        author: "Ashley Broussard",
+};
+
+export const seoProducts = {
+        "daily-square": {
+                title: "Daily Square Ritual – Auto GitHub Commits",
+                description:
+                        "Never miss a green square again. Automate daily Git pushes with stealthy flair.",
+                url: "https://fleurdevie.gumroad.com/l/daily-square",
+                image: "https://yourcdn.com/assets/dailysquare-banner.png",
+                price: "10.00",
+        },
+        "prompt-storm": {
+                title: "PromptStorm – 100 Strategic AI Prompts",
+                description:
+                        "Market better, think faster, and generate content like a boss with this AI prompt bundle.",
+                url: "https://fleurdevie.gumroad.com/l/100prompt-storm",
+                image: "https://yourcdn.com/assets/promptstorm-banner.png",
+                price: "25.00",
+        },
+};
+
+// Usage Example: Use on another page, mainpage ?
+// import SEOHead from "@/UXUI/Components/SeoHead";
+// import { seoProducts } from "@/utils/seoPresets";
+
+// const meta = seoProducts["prompt-storm"];
+
+// <SEOHead {...meta} />;


### PR DESCRIPTION
## Summary
- add frontend version of `seoCheckRunner` and product presets
- update Post and seoTags components to use new module

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68411698953c832592393feaac6bca41