### PR TITLE
Fix incorrect seoCheckRunner path

### DIFF
--- a/backend/scripts/masterPoster.js
+++ b/backend/scripts/masterPoster.js
@@ -1,6 +1,7 @@
 /** @format */
 
-const { runSeoCheck } = require("../utils/seoCheckRunner");
+// The SEO helper lives in this same folder, not ../utils
+const { runSeoCheck } = require("./seoCheckRunner.js");
 
 posts.forEach((post) => {
 	if (

--- a/backend/scripts/seoChecker.js
+++ b/backend/scripts/seoChecker.js
@@ -2,7 +2,8 @@
 
 // /scripts/seoChecker.js
 import chalk from "chalk";
-import { runSeoCheck } from "../utils/seoCheckRunner.js";
+// Import the SEO checker from this directory
+import { runSeoCheck } from "./seoCheckRunner.js";
 
 const productKey = process.argv[2];
 const result = runSeoCheck(productKey);


### PR DESCRIPTION
## Summary
- fix script imports of seoCheckRunner

## Testing
- `node backend/scripts/masterPoster.js` *(fails: posts is not defined)*
- `node backend/scripts/seoChecker.js testkey` *(fails: Cannot find package 'chalk')*

------
https://chatgpt.com/codex/tasks/task_e_684111aa14b08325b1655b109057f7f4