### PR TITLE
Add validation tests

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -3,7 +3,8 @@
   "version": "1.0.0",
   "main": "index.js",
   "scripts": {
-    "start": "node server.js"
+    "start": "node server.js",
+    "test": "jest"
   },
   "keywords": [],
   "author": "",
@@ -26,5 +27,8 @@
     "p-limit": "^6.2.0",
     "playwright": "^1.52.0",
     "shelljs": "^0.10.0"
+  },
+  "devDependencies": {
+    "jest": "^29.7.0"
   }
 }

--- a/backend/tests/validateSettings.test.js
+++ b/backend/tests/validateSettings.test.js
@@ -1,0 +1,32 @@
+const fs = require('fs');
+const path = require('path');
+const { validateSettings } = require('../utils/validateSettings');
+
+describe('validateSettings', () => {
+  const validPath = '../config/settings.json';
+
+  test('successfully validates default settings', () => {
+    const exitSpy = jest.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('process.exit');
+    });
+    expect(() => validateSettings(validPath)).not.toThrow();
+    expect(exitSpy).not.toHaveBeenCalled();
+    exitSpy.mockRestore();
+  });
+
+  test('throws error for missing active_platforms', () => {
+    const baseFile = path.resolve(__dirname, "../config/settings.json");
+    const data = JSON.parse(fs.readFileSync(baseFile, 'utf-8'));
+    delete data.active_platforms;
+    const tempPathRel = '../tests/temp-invalid-settings.json';
+    const tempPath = path.resolve(__dirname, 'temp-invalid-settings.json');
+    fs.writeFileSync(tempPath, JSON.stringify(data));
+    const exitSpy = jest.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('process.exit');
+    });
+    expect(() => validateSettings(tempPathRel)).toThrow('process.exit');
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    exitSpy.mockRestore();
+    fs.unlinkSync(tempPath);
+  });
+});


### PR DESCRIPTION
## Summary
- add Jest devDependency and test script to backend package.json
- test `validateSettings` with valid and invalid configs

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68411448fe888325abcfc9c636668d96