### PR TITLE
Fix variable initialization in masterPoster

### DIFF
--- a/backend/scripts/masterPoster.js
+++ b/backend/scripts/masterPoster.js
@@ -1,6 +1,27 @@
 /** @format */
 
-const { runSeoCheck } = require("../utils/seoCheckRunner");
+const { runSeoCheck } = require("./seoCheckRunner.js");
+const fs = require("fs");
+const path = require("path");
+
+// Helper to load JSON files that may contain comments
+function loadJSON(relativePath) {
+        const file = path.resolve(__dirname, relativePath);
+        const raw = fs.readFileSync(file, "utf-8");
+        const cleaned = raw.replace(/(^\s*\/\/.*$)/gm, "");
+        return JSON.parse(cleaned);
+}
+
+// Load configuration and queue data
+const config = loadJSON("../config/settings.json");
+const posts = loadJSON("../queue/postQueue.json");
+
+// Determine today's platform in a simple rotating manner
+const dayIndex = new Date().getDay() % config.active_platforms.length;
+const todayPlatform = config.active_platforms[dayIndex];
+
+// Track how many posts we've sent out today
+let postedCount = 0;
 
 posts.forEach((post) => {
 	if (


### PR DESCRIPTION
## Summary
- load queue and settings data in `masterPoster`
- implement simple platform rotation
- track posting count

## Testing
- `node backend/scripts/masterPoster.js | head` *(fails: cannot read property 'includes' of undefined but script runs until that point)*

------
https://chatgpt.com/codex/tasks/task_e_68411a22d8208325a6801fd2d3e6bbf7