### PR TITLE
Implement stub posting functions

### DIFF
--- a/backend/scripts/platforms/adult/post-to-discord.js
+++ b/backend/scripts/platforms/adult/post-to-discord.js
@@ -1,0 +1,4 @@
+export default async function postToDiscord(payload) {
+  console.log('Posting to discord:', payload);
+  return Promise.resolve('stub discord');
+}

--- a/backend/scripts/platforms/adult/post-to-onlyfans.js
+++ b/backend/scripts/platforms/adult/post-to-onlyfans.js
@@ -1,0 +1,4 @@
+export default async function postToOnlyfans(payload) {
+  console.log('Posting to onlyfans:', payload);
+  return Promise.resolve('stub onlyfans');
+}

--- a/backend/scripts/platforms/content/post-to-kofi.js
+++ b/backend/scripts/platforms/content/post-to-kofi.js
@@ -1,0 +1,4 @@
+export default async function postToKofi(payload) {
+  console.log('Posting to kofi:', payload);
+  return Promise.resolve('stub kofi');
+}

--- a/backend/scripts/platforms/content/post-to-substack.js
+++ b/backend/scripts/platforms/content/post-to-substack.js
@@ -1,0 +1,4 @@
+export default async function postToSubstack(payload) {
+  console.log('Posting to substack:', payload);
+  return Promise.resolve('stub substack');
+}

--- a/backend/scripts/platforms/content/post-to-youtube.js
+++ b/backend/scripts/platforms/content/post-to-youtube.js
@@ -1,0 +1,4 @@
+export default async function postToYoutube(payload) {
+  console.log('Posting to youtube:', payload);
+  return Promise.resolve('stub youtube');
+}

--- a/backend/scripts/platforms/dev/post-to-devto.js
+++ b/backend/scripts/platforms/dev/post-to-devto.js
@@ -1,0 +1,4 @@
+export default async function postToDevto(payload) {
+  console.log('Posting to devto:', payload);
+  return Promise.resolve('stub devto');
+}

--- a/backend/scripts/platforms/dev/post-to-hashnode.js
+++ b/backend/scripts/platforms/dev/post-to-hashnode.js
@@ -1,0 +1,4 @@
+export default async function postToHashnode(payload) {
+  console.log('Posting to hashnode:', payload);
+  return Promise.resolve('stub hashnode');
+}

--- a/backend/scripts/platforms/dev/post-to-producthunt.js
+++ b/backend/scripts/platforms/dev/post-to-producthunt.js
@@ -1,0 +1,4 @@
+export default async function postToProducthunt(payload) {
+  console.log('Posting to producthunt:', payload);
+  return Promise.resolve('stub producthunt');
+}

--- a/backend/scripts/platforms/marketplace/post-to-amazon.js
+++ b/backend/scripts/platforms/marketplace/post-to-amazon.js
@@ -1,0 +1,4 @@
+export default async function postToAmazon(payload) {
+  console.log('Posting to amazon:', payload);
+  return Promise.resolve('stub amazon');
+}

--- a/backend/scripts/platforms/marketplace/post-to-gumroad.js
+++ b/backend/scripts/platforms/marketplace/post-to-gumroad.js
@@ -1,0 +1,4 @@
+export default async function postToGumroad(payload) {
+  console.log('Posting to gumroad:', payload);
+  return Promise.resolve('stub gumroad');
+}

--- a/backend/scripts/platforms/post-to-all.js
+++ b/backend/scripts/platforms/post-to-all.js
@@ -6,19 +6,19 @@
  */
 
 // Import your platform posting functions
-import postToX from "./platforms/post-to-x.js";
-import postToFacebook from "./platforms/post-to-facebook.js";
-import postToLinkedin from "./platforms/post-to-linkedin.js";
-import postToPinterest from "./platforms/post-to-pinterest.js";
-import postToReddit from "./platforms/post-to-reddit.js";
-import postToTumblr from "./platforms/post-to-tumblr.js";
-import postToOnlyfans from "./platforms/post-to-onlyfans.js";
-import postToKofi from "./platforms/post-to-kofi.js";
-import postToDiscord from "./platforms/post-to-discord.js";
-import postToDevto from "./platforms/post-to-devto.js";
-import postToHashnode from "./platforms/post-to-hashnode.js";
-import postToProducthunt from "./platforms/post-to-producthunt.js";
-import postToAmazon from "./platforms/post-to-amazon.js";
+import postToX from "./social/post-to-x.js";
+import postToFacebook from "./social/post-to-facebook.js";
+import postToLinkedin from "./social/post-to-linkedin.js";
+import postToPinterest from "./social/post-to-pinterest.js";
+import postToReddit from "./social/post-to-reddit.js";
+import postToTumblr from "./social/post-to-tumblr.js";
+import postToOnlyfans from "./adult/post-to-onlyfans.js";
+import postToKofi from "./content/post-to-kofi.js";
+import postToDiscord from "./adult/post-to-discord.js";
+import postToDevto from "./dev/post-to-devto.js";
+import postToHashnode from "./dev/post-to-hashnode.js";
+import postToProducthunt from "./dev/post-to-producthunt.js";
+import postToAmazon from "./marketplace/post-to-amazon.js";
 
 // Map of platform name to function
 const platformMap = {

--- a/backend/scripts/platforms/social/post-to-facebook.js
+++ b/backend/scripts/platforms/social/post-to-facebook.js
@@ -1,0 +1,4 @@
+export default async function postToFacebook(payload) {
+  console.log('Posting to facebook:', payload);
+  return Promise.resolve('stub facebook');
+}

--- a/backend/scripts/platforms/social/post-to-instagram.js
+++ b/backend/scripts/platforms/social/post-to-instagram.js
@@ -1,0 +1,4 @@
+export default async function postToInstagram(payload) {
+  console.log('Posting to instagram:', payload);
+  return Promise.resolve('stub instagram');
+}

--- a/backend/scripts/platforms/social/post-to-linkedin.js
+++ b/backend/scripts/platforms/social/post-to-linkedin.js
@@ -1,0 +1,4 @@
+export default async function postToLinkedin(payload) {
+  console.log('Posting to linkedin:', payload);
+  return Promise.resolve('stub linkedin');
+}

--- a/backend/scripts/platforms/social/post-to-pinterest.js
+++ b/backend/scripts/platforms/social/post-to-pinterest.js
@@ -1,0 +1,4 @@
+export default async function postToPinterest(payload) {
+  console.log('Posting to pinterest:', payload);
+  return Promise.resolve('stub pinterest');
+}

--- a/backend/scripts/platforms/social/post-to-reddit.js
+++ b/backend/scripts/platforms/social/post-to-reddit.js
@@ -1,0 +1,4 @@
+export default async function postToReddit(payload) {
+  console.log('Posting to reddit:', payload);
+  return Promise.resolve('stub reddit');
+}

--- a/backend/scripts/platforms/social/post-to-threads.js
+++ b/backend/scripts/platforms/social/post-to-threads.js
@@ -1,0 +1,4 @@
+export default async function postToThreads(payload) {
+  console.log('Posting to threads:', payload);
+  return Promise.resolve('stub threads');
+}

--- a/backend/scripts/platforms/social/post-to-tiktok.js
+++ b/backend/scripts/platforms/social/post-to-tiktok.js
@@ -1,0 +1,4 @@
+export default async function postToTiktok(payload) {
+  console.log('Posting to tiktok:', payload);
+  return Promise.resolve('stub tiktok');
+}

--- a/backend/scripts/platforms/social/post-to-tumblr.js
+++ b/backend/scripts/platforms/social/post-to-tumblr.js
@@ -1,0 +1,4 @@
+export default async function postToTumblr(payload) {
+  console.log('Posting to tumblr:', payload);
+  return Promise.resolve('stub tumblr');
+}

--- a/backend/scripts/platforms/social/post-to-x.js
+++ b/backend/scripts/platforms/social/post-to-x.js
@@ -1,0 +1,4 @@
+export default async function postToX(payload) {
+  console.log('Posting to x:', payload);
+  return Promise.resolve('stub x');
+}


### PR DESCRIPTION
## Summary
- add simple posting stubs for every platform script
- correct import paths in `post-to-all.js`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68411a154a288325bf4677314c3b19ce