### PR TITLE
Clean settings.json and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Only posts with `"status": "approved"` in the `postQueue.json` are eligible for 
 ---
 
 ## ⚙️ System Settings
+Copy `backend/config/settings.template` to `backend/config/settings.json` and remove any comments.
 Control how PostPunk behaves globally:
 ```json
 {

--- a/backend/config/settings.json
+++ b/backend/config/settings.json
@@ -6,7 +6,6 @@
   "campaign_start": "2025-05-08",
   "campaign_end": "2025-05-31",
 
-  // Optional extras:
   "timezone": "America/Chicago",
   "posting_window": { "start": "09:00", "end": "17:00" },
   "retry_on_fail": true,


### PR DESCRIPTION
## Summary
- remove inline comments from `backend/config/settings.json`
- document how to copy `settings.template` in README

## Testing
- `node -e "const s = require('./backend/config/settings.json'); console.log(s.active_platforms.join(','))"`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6841193a8f588325a63a50491c19078a