### PR TITLE
Fix CJS compatibility for SEO scripts

### DIFF
--- a/backend/scripts/seoCheckRunner.js
+++ b/backend/scripts/seoCheckRunner.js
@@ -1,9 +1,9 @@
 /** @format */
 
 // /utils/seoCheckRunner.js
-import { seoProducts } from "../utils/seoPresets.js";
+const { seoProducts } = require("../utils/seoPresets.js");
 
-export function runSeoCheck(productKey) {
+function runSeoCheck(productKey) {
 	const data = seoProducts[productKey];
 
 	if (!data) {
@@ -50,3 +50,7 @@ export function runSeoCheck(productKey) {
 		},
 	};
 }
+
+module.exports = {
+        runSeoCheck,
+};

--- a/backend/scripts/seoChecker.js
+++ b/backend/scripts/seoChecker.js
@@ -1,33 +1,46 @@
 /** @format */
 
 // /scripts/seoChecker.js
-import chalk from "chalk";
-import { runSeoCheck } from "../utils/seoCheckRunner.js";
+const { runSeoCheck } = require("./seoCheckRunner.js");
 
-const productKey = process.argv[2];
-const result = runSeoCheck(productKey);
+(async () => {
+        let chalk;
+        try {
+                chalk = (await import("chalk")).default;
+        } catch {
+                chalk = {
+                        red: (s) => s,
+                        cyan: (s) => s,
+                        yellow: (s) => s,
+                        green: (s) => s,
+                };
+        }
 
-if (!result.ok) {
-	console.error(chalk.red(result.error));
-	process.exit(1);
-}
+        const productKey = process.argv[2];
+        const result = runSeoCheck(productKey);
 
-console.log(chalk.cyan(`🔍 SEO Preflight Check: ${result.meta.title}`));
-console.log("———————————————————————————————");
+        if (!result.ok) {
+                console.error(chalk.red(result.error));
+                process.exit(1);
+        }
 
-console.log(chalk.yellow("Meta Tags Preview"));
-console.log("• Title:", result.meta.title);
-console.log("• Description:", result.meta.description);
-console.log("• Image:", result.meta.image);
-console.log("• URL:", result.meta.url);
+        console.log(chalk.cyan(`🔍 SEO Preflight Check: ${result.meta.title}`));
+        console.log("———————————————————————————————");
 
-console.log("\n" + chalk.yellow("Schema Markup Snippet (JSON-LD)"));
-console.log(JSON.stringify(result.schema, null, 2));
+        console.log(chalk.yellow("Meta Tags Preview"));
+        console.log("• Title:", result.meta.title);
+        console.log("• Description:", result.meta.description);
+        console.log("• Image:", result.meta.image);
+        console.log("• URL:", result.meta.url);
 
-console.log("\n" + chalk.green("✅ Manual steps to follow:"));
-Object.entries(result.todoLinks).forEach(([label, url]) =>
-	console.log(`• [${label}] → ${url}`)
-);
+        console.log("\n" + chalk.yellow("Schema Markup Snippet (JSON-LD)"));
+        console.log(JSON.stringify(result.schema, null, 2));
 
-// To use later in terminal make a button for normies:
-// node scripts/seoChecker.js prompt-storm
+        console.log("\n" + chalk.green("✅ Manual steps to follow:"));
+        Object.entries(result.todoLinks).forEach(([label, url]) =>
+                console.log(`• [${label}] → ${url}`)
+        );
+
+        // To use later in terminal make a button for normies:
+        // node scripts/seoChecker.js prompt-storm
+})();

--- a/backend/utils/seoPresets.js
+++ b/backend/utils/seoPresets.js
@@ -1,11 +1,11 @@
 /** @format */
 
-export const seoDefaults = {
-	platform: "Cross-platform",
-	author: "Ashley Broussard",
+const seoDefaults = {
+        platform: "Cross-platform",
+        author: "Ashley Broussard",
 };
 
-export const seoProducts = {
+const seoProducts = {
 	"daily-square": {
 		title: "Daily Square Ritual – Auto GitHub Commits",
 		description:
@@ -22,6 +22,11 @@ export const seoProducts = {
 		image: "https://yourcdn.com/assets/promptstorm-banner.png",
 		price: "25.00",
 	},
+};
+
+module.exports = {
+        seoDefaults,
+        seoProducts,
 };
 
 


### PR DESCRIPTION
## Summary
- convert SEO helper modules to CommonJS
- dynamically load `chalk` inside `seoChecker.js`
- update `seoChecker.js` to work without ESM support

## Testing
- `node backend/scripts/seoChecker.js testkey`
- `node backend/scripts/seoChecker.js prompt-storm | head -n 20`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684116980598832594467136bd85d35e