### PR TITLE
Load settings and queue in masterPoster

### DIFF
--- a/backend/scripts/masterPoster.js
+++ b/backend/scripts/masterPoster.js
@@ -2,6 +2,20 @@
 
 const { runSeoCheck } = require("../utils/seoCheckRunner");
 
+// Load queued posts
+const posts = require("../queue/postQueue.json");
+
+// Load global configuration
+const config = require("../config/settings.json");
+
+// Determine today's platform using round-robin across active platforms
+const dayIndex = new Date().getDay();
+const todayPlatform =
+        config.active_platforms[dayIndex % config.active_platforms.length];
+
+// Track number of posts successfully sent today
+let postedCount = 0;
+
 posts.forEach((post) => {
 	if (
 		post.status === "approved" &&


### PR DESCRIPTION
## Summary
- import post queue and settings into masterPoster
- pick today's platform from active platforms and initialize posting counter

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684116951d9883258ca86028840d696c