### PR TITLE
Add canonical and UTM helpers

### DIFF
--- a/backend/posts/canonical.json
+++ b/backend/posts/canonical.json
@@ -1,0 +1,18 @@
+[
+  {
+    "title": "PostPunk Intro",
+    "originalUrl": "https://example.com/postpunk-intro",
+    "isCanonical": true,
+    "utmParams": "",
+    "funnelUrl": "https://gumroad.com/l/postpunk",
+    "platformVariants": [
+      {
+        "platform": "Dev.to",
+        "postUrl": "https://dev.to/ash/postpunk-intro",
+        "canonicalTarget": "https://example.com/postpunk-intro",
+        "utmParams": "?utm_source=devto&utm_medium=referral&utm_campaign=launch",
+        "postedAt": "2025-05-10T10:00:00Z"
+      }
+    ]
+  }
+]

--- a/backend/utils/postUtils.js
+++ b/backend/utils/postUtils.js
@@ -1,0 +1,73 @@
+/** @format */
+
+const fs = require('fs');
+const path = require('path');
+const axios = require('axios');
+
+// JSON file storing canonical relationships
+const DB_PATH = path.join(__dirname, '../posts/canonical.json');
+
+function loadCanonicalDB() {
+  try {
+    return JSON.parse(fs.readFileSync(DB_PATH, 'utf-8'));
+  } catch {
+    return [];
+  }
+}
+
+function saveCanonicalDB(data) {
+  fs.writeFileSync(DB_PATH, JSON.stringify(data, null, 2));
+}
+
+// Remove UTM parameters from a URL
+function stripUtm(url) {
+  try {
+    const u = new URL(url);
+    for (const key of [...u.searchParams.keys()]) {
+      if (key.toLowerCase().startsWith('utm_')) {
+        u.searchParams.delete(key);
+      }
+    }
+    u.hash = '';
+    return u.origin + u.pathname + (u.searchParams.toString() ? `?${u.searchParams.toString()}` : '');
+  } catch {
+    return url;
+  }
+}
+
+// Append UTM parameters to a URL (used for monetized funnels)
+function buildUtm(url, params = {}) {
+  const clean = stripUtm(url);
+  const query = new URLSearchParams(params).toString();
+  if (!query) return clean;
+  return clean + (clean.includes('?') ? '&' : '?') + query;
+}
+
+// Validate that a canonical target is reachable
+async function validateCanonicalTarget(url) {
+  try {
+    const res = await axios.head(url, { timeout: 5000 });
+    return res.status >= 200 && res.status < 400;
+  } catch {
+    return false;
+  }
+}
+
+// Save or update canonical record in JSON DB
+function saveCanonicalRecord(record) {
+  const db = loadCanonicalDB();
+  const idx = db.findIndex((r) => r.originalUrl === record.originalUrl);
+  if (idx >= 0) {
+    db[idx] = { ...db[idx], ...record };
+  } else {
+    db.push(record);
+  }
+  saveCanonicalDB(db);
+}
+
+module.exports = {
+  stripUtm,
+  buildUtm,
+  validateCanonicalTarget,
+  saveCanonicalRecord,
+};

--- a/docs/canonical-utm-handling.md
+++ b/docs/canonical-utm-handling.md
@@ -1,0 +1,36 @@
+# Canonical & UTM Handling
+
+This document outlines how PostPunk manages canonical links and UTM tracking.
+
+## Goals
+- Mark original articles as canonical to consolidate SEO authority.
+- Remixed or syndicated versions reference the original via a canonical link or attribution text when a platform does not support canonical tags.
+- UTM parameters are used only on monetized funnel links (e.g. Gumroad or Ko-fi). Canonical URLs remain clean.
+- Store the relationship between the canonical article and its variants in `backend/posts/canonical.json`.
+
+## Schema Example
+```json
+{
+  "title": "PostPunk Intro",
+  "originalUrl": "https://example.com/postpunk-intro",
+  "isCanonical": true,
+  "utmParams": "",
+  "funnelUrl": "https://gumroad.com/l/postpunk",
+  "platformVariants": [
+    {
+      "platform": "Dev.to",
+      "postUrl": "https://dev.to/ash/postpunk-intro",
+      "canonicalTarget": "https://example.com/postpunk-intro",
+      "utmParams": "?utm_source=devto&utm_medium=referral&utm_campaign=launch",
+      "postedAt": "2025-05-10T10:00:00Z"
+    }
+  ]
+}
+```
+
+## Logic Overview
+1. Canonical posts do not require a canonical tag (they point to themselves).
+2. Syndicated posts inject `<link rel="canonical" href="ORIGINAL_URL" />` or an "Originally published" attribution.
+3. Canonical URLs must never include UTM parameters.
+4. Monetized funnel links may include UTM tracking using `buildUtm()` from `backend/utils/postUtils.js`.
+5. `validateCanonicalTarget()` verifies that the canonical target is reachable before a post is published.


### PR DESCRIPTION
## Summary
- add canonical + UTM helper utilities and JSON store
- document canonical & UTM guidelines

## Testing
- `npm test` *(fails: Missing script `test`)*

------
https://chatgpt.com/codex/tasks/task_e_68411d59777c832597a03e04499aff52